### PR TITLE
refactor: rename git_diff_to_clipboard alias to copy_diff

### DIFF
--- a/aliases.sh
+++ b/aliases.sh
@@ -8,7 +8,7 @@ alias docs="cd ~/Documents"
 
 # Git
 alias clean_branches='git branch | grep -v "$(git branch --show-current)" | xargs git branch -D'
-alias git_diff_to_clipboard="git diff --cached | xclip -selection clipboard"
+alias copy_diff="git diff --cached | xclip -selection clipboard"
 alias merge_branch='git branch --format="%(refname:short)" | fzf | xargs git merge'
 alias select_branch='git branch --format="%(refname:short)" | fzf | xargs git checkout'
 alias delete_branch='git branch --format="%(refname:short)" | fzf | xargs git branch -D'


### PR DESCRIPTION
- Update alias name for clarity and consistency with other Git aliases